### PR TITLE
Migrate news source to free RSS feeds (keyless, with images)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## What this is
 
 A native Android app (Java) that displays the top three headlines from a chosen
-[newsapi.org](https://newsapi.org) source — both full-screen in-app (a 3-pane landscape layout)
+[Google News RSS](https://news.google.com/) source — both full-screen in-app (a 3-pane landscape layout)
 and as a home-screen widget. Data is fetched in the background via an Android
 `SyncAdapter` + `ContentProvider`, triggered on an alarm. Modernized in 2024 from the original
 2016 toolchain (Gradle 2.14.1 / AGP 2.2.1 / jcenter / `android.support`) to Gradle 8.7 / AGP 8.5.2 /
@@ -26,10 +26,20 @@ Requires JDK 17, Android SDK for **API 34**. Gradle/AGP download via the bundled
 The release signing config and `keystore.jks` are committed intentionally (demo project) — keystore
 password `threenewspass`, key alias `keyalias`. There is no separate debug-vs-release signing split.
 
-## API key
+## News source
 
-`mysyncadapter/src/main/res/values/apikeys.xml` holds `<string name="newsapikey">`. It is committed
-(not gitignored), so a working key may already be present — check before assuming setup is needed.
+Headlines come from **Google News RSS** — free, no API key, no signup, no quota. The feed URLs live in
+`mysyncadapter/.../res/values/strings.xml`: `apiurl` is the per-source search feed
+(`.../rss/search?q=site:%1$s+when:2d`) and `rss_top_url` is the unified top-stories feed. The selectable
+sources are domains (e.g. `cnn.com`) in `newssources.xml`, plus the sentinel value `top` for the
+top-stories feed; both arrays are index-aligned with `newssourcesnames.xml`.
+
+The response is RSS XML, parsed with Android's built-in `XmlPullParser` (no extra dependency). Google
+News RSS items have **no image**, so the `IMG` column is left null and story tiles show the placeholder.
+Titles arrive as "Headline - Publisher"; the trailing publisher suffix is stripped on parse.
+
+_History:_ the app originally used newsapi.org with a committed key in `apikeys.xml` (now deleted).
+That endpoint (v1) was shut down and its free tier was dev-only — hence the move to RSS.
 
 ## Architecture
 
@@ -38,7 +48,7 @@ Two Gradle modules, with `:mobile` depending on `:mysyncadapter`:
 - **`:mysyncadapter`** (`com.tbse.threenews.mysyncadapter`) — the headless data layer (an Android
   library). Owns fetching, storage, and the sync framework. No UI.
 - **`:mobile`** (`com.tbse.threenews`, applicationId `com.tbse.nano.threenews`) — UI + widget.
-  Reads data only through the ContentProvider; it never calls newsapi directly.
+  Reads data only through the ContentProvider; it never fetches news directly.
 
 ### Data flow (the part that needs multiple files to grasp)
 
@@ -49,9 +59,10 @@ Two Gradle modules, with `:mobile` depending on `:mysyncadapter`:
    that exists only to drive the SyncAdapter framework — no real authentication.
 3. **`MyService`** is the bound SyncAdapter service; it hands the framework a **`MySyncAdapter`**.
 4. **`MySyncAdapter.onPerformSync`** reads the chosen source from SharedPreferences, does a Volley
-   HTTP request to newsapi.org, parses the JSON, and writes rows into the ContentProvider via
-   `CONTENT_URI`. Column constants (`_ID`, `IMG`, `SOURCE`, `HEADLINE`, `LINK`, `DATE`) are the
-   contract — defined in `MyContentProvider` and imported statically by everyone else.
+   HTTP request to the Google News RSS feed for that source, parses the RSS XML with `XmlPullParser`,
+   and writes rows into the ContentProvider via `CONTENT_URI`. Column constants
+   (`_ID`, `IMG`, `SOURCE`, `HEADLINE`, `LINK`, `DATE`) are the contract — defined in
+   `MyContentProvider` and imported statically by everyone else.
 5. **`MyContentProvider`** persists into a SQLite DB (`newsdb`, table `news`, `DBVERSION`).
 6. **`MainNewsActivity`** observes the provider with a `CursorLoader` + `ContentObserver` and
    renders the three stories; **`MyAppWidget`** reads the same provider for the widget.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## What this is
 
 A native Android app (Java) that displays the top three headlines from a chosen
-[Google News RSS](https://news.google.com/) source — both full-screen in-app (a 3-pane landscape layout)
+RSS-fed source (BBC, NYT, Guardian, …) — both full-screen in-app (a 3-pane landscape layout)
 and as a home-screen widget. Data is fetched in the background via an Android
 `SyncAdapter` + `ContentProvider`, triggered on an alarm. Modernized in 2024 from the original
 2016 toolchain (Gradle 2.14.1 / AGP 2.2.1 / jcenter / `android.support`) to Gradle 8.7 / AGP 8.5.2 /
@@ -28,15 +28,18 @@ password `threenewspass`, key alias `keyalias`. There is no separate debug-vs-re
 
 ## News source
 
-Headlines come from **Google News RSS** — free, no API key, no signup, no quota. The feed URLs live in
-`mysyncadapter/.../res/values/strings.xml`: `apiurl` is the per-source search feed
-(`.../rss/search?q=site:%1$s+when:2d`) and `rss_top_url` is the unified top-stories feed. The selectable
-sources are domains (e.g. `cnn.com`) in `newssources.xml`, plus the sentinel value `top` for the
-top-stories feed; both arrays are index-aligned with `newssourcesnames.xml`.
+Headlines come from the news outlets' own **public RSS feeds** — free, no API key, no signup, no quota.
+A source is described by three **index-aligned** resource arrays in `mysyncadapter/.../res/values/`:
+`newssources.xml` (slug, e.g. `bbc` — stored in the `news_source` pref and the `SOURCE` column),
+`newssourcesnames.xml` (display name), and `newsfeeds.xml` (the HTTPS feed URL). `startRequestForSource`
+resolves slug → URL by walking those arrays; keep all three the same length and order. The default slug
+is `default_source` in `strings.xml`. All feeds must be **HTTPS** — API 34 blocks cleartext, which is
+why the http-only CNN feed was dropped.
 
-The response is RSS XML, parsed with Android's built-in `XmlPullParser` (no extra dependency). Google
-News RSS items have **no image**, so the `IMG` column is left null and story tiles show the placeholder.
-Titles arrive as "Headline - Publisher"; the trailing publisher suffix is stripped on parse.
+The response is RSS XML, parsed with Android's built-in `XmlPullParser` (no extra dependency). Each
+item's image comes from its `media:content` / `media:thumbnail` / `enclosure` tag (the largest by
+`width` is kept); if none, `IMG` is left null and the tile shows the placeholder. `pubDate` is RFC-822
+with either a zone name (`GMT`) or numeric offset (`+0000`), so two Joda formatters are tried.
 
 _History:_ the app originally used newsapi.org with a committed key in `apikeys.xml` (now deleted).
 That endpoint (v1) was shut down and its free tier was dev-only — hence the move to RSS.
@@ -59,7 +62,7 @@ Two Gradle modules, with `:mobile` depending on `:mysyncadapter`:
    that exists only to drive the SyncAdapter framework — no real authentication.
 3. **`MyService`** is the bound SyncAdapter service; it hands the framework a **`MySyncAdapter`**.
 4. **`MySyncAdapter.onPerformSync`** reads the chosen source from SharedPreferences, does a Volley
-   HTTP request to the Google News RSS feed for that source, parses the RSS XML with `XmlPullParser`,
+   HTTP request to that source's RSS feed, parses the RSS XML with `XmlPullParser`,
    and writes rows into the ContentProvider via `CONTENT_URI`. Column constants
    (`_ID`, `IMG`, `SOURCE`, `HEADLINE`, `LINK`, `DATE`) are the contract — defined in
    `MyContentProvider` and imported statically by everyone else.
@@ -69,9 +72,9 @@ Two Gradle modules, with `:mobile` depending on `:mysyncadapter`:
 7. **`MyTransform`** is a Picasso `Transformation` used to fit headline images to the pane size.
 
 Images are loaded with **Picasso**, HTTP via **Volley**, dates via **Joda-Time**. The available
-news sources are defined as parallel arrays in `res/values/newssources.xml` (source ids) and
-`newssourcesnames.xml` (display names); `MySyncAdapter` zips them into a `sourceTo_name` map and
-`SettingsFragment` surfaces them as a preference list.
+news sources are defined as parallel arrays in `res/values/` — `newssources.xml` (slugs),
+`newssourcesnames.xml` (display names), and `newsfeeds.xml` (feed URLs); `MySyncAdapter` zips the first
+two into a `sourceToName` map and `SettingsFragment` surfaces them as a preference list.
 
 ### Things to watch
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 A native Android news-display app. It shows the top three headlines from a
 chosen source, both in-app (a full-screen 3-pane layout) and via a home-screen
-widget. Headlines come from [Google News RSS](https://news.google.com/) — free,
-no API key required. News is fetched in the background through an Android
-`SyncAdapter` + `ContentProvider`, refreshed on an alarm.
+widget. Headlines come from the news outlets' own public RSS feeds (BBC, ABC,
+NBC, New York Times, The Guardian, Ars Technica, WIRED, Sky News) — free, no API
+key required, and each story carries its image. News is fetched in the
+background through an Android `SyncAdapter` + `ContentProvider`, refreshed on an
+alarm.
 
 ## Modules
 
@@ -22,8 +24,8 @@ no API key required. News is fetched in the background through an Android
 
 ## Setup
 
-None — headlines are fetched from public Google News RSS feeds, so there is no
-API key to configure. Pick a source from the in-app settings; the default is CNN.
+None — headlines are fetched from the outlets' public RSS feeds, so there is no
+API key to configure. Pick a source from the in-app settings; the default is BBC.
 
 ## Build
 
@@ -43,7 +45,9 @@ repositories. The Firebase Analytics/Crash and Hugo logging integrations were
 removed since they were non-essential and required dead dependencies/config.
 
 The news source was later migrated from newsapi.org (whose v1 endpoint was shut
-down and whose free tier requires a key and is dev-only) to Google News RSS,
-which is free and keyless. The fetch still uses Volley; the response is RSS XML
-parsed with Android's built-in `XmlPullParser`. Google News RSS items carry no
-image, so story tiles show a placeholder.
+down and whose free tier requires a key and is dev-only) to the outlets' own
+public RSS feeds, which are free and keyless. The fetch still uses Volley; the
+response is RSS XML parsed with Android's built-in `XmlPullParser`, and each
+item's image is taken from its `media:content` / `media:thumbnail` / `enclosure`
+tag. Source slug, display name, and feed URL live in the index-aligned
+`newssources` / `newssourcesnames` / `newsfeeds` resource arrays.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Three-News
 
 A native Android news-display app. It shows the top three headlines from a
-chosen [newsapi.org](https://newsapi.org) source, both in-app (a full-screen
-3-pane layout) and via a home-screen widget. News is fetched in the background
-through an Android `SyncAdapter` + `ContentProvider`, refreshed on an alarm.
+chosen source, both in-app (a full-screen 3-pane layout) and via a home-screen
+widget. Headlines come from [Google News RSS](https://news.google.com/) — free,
+no API key required. News is fetched in the background through an Android
+`SyncAdapter` + `ContentProvider`, refreshed on an alarm.
 
 ## Modules
 
@@ -21,15 +22,8 @@ through an Android `SyncAdapter` + `ContentProvider`, refreshed on an alarm.
 
 ## Setup
 
-Add your newsapi.org API key to
-`mysyncadapter/src/main/res/values/apikeys.xml`:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="newsapikey" translatable="false">PUT_YOUR_KEY_HERE</string>
-</resources>
-```
+None — headlines are fetched from public Google News RSS feeds, so there is no
+API key to configure. Pick a source from the in-app settings; the default is CNN.
 
 ## Build
 
@@ -47,3 +41,9 @@ AGP 2.2.1 / `jcenter` / the `android.support` libraries) to a current build:
 Gradle 8.7, AGP 8.5.2, AndroidX, and the `google()` + `mavenCentral()`
 repositories. The Firebase Analytics/Crash and Hugo logging integrations were
 removed since they were non-essential and required dead dependencies/config.
+
+The news source was later migrated from newsapi.org (whose v1 endpoint was shut
+down and whose free tier requires a key and is dev-only) to Google News RSS,
+which is free and keyless. The fetch still uses Volley; the response is RSS XML
+parsed with Android's built-in `XmlPullParser`. Google News RSS items carry no
+image, so story tiles show a placeholder.

--- a/mysyncadapter/src/main/java/com/tbse/threenews/mysyncadapter/MySyncAdapter.java
+++ b/mysyncadapter/src/main/java/com/tbse/threenews/mysyncadapter/MySyncAdapter.java
@@ -29,18 +29,20 @@ import com.android.volley.toolbox.StringRequest;
 import com.android.volley.toolbox.Volley;
 
 import org.joda.time.DateTime;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
 
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 
 import static android.content.Context.ACCOUNT_SERVICE;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.CONTENT_URI;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.DATE;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.HEADLINE;
-import static com.tbse.threenews.mysyncadapter.MyContentProvider.IMG;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.LINK;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.SOURCE;
 import static com.tbse.threenews.mysyncadapter.NewsAlarmManager.ACCOUNT;
@@ -51,6 +53,10 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
 
     private static RequestQueue queue;
     public static HashMap<String, String> sourceToName;
+
+    // Google News RSS publishes RFC-822 dates, e.g. "Tue, 24 Jun 2025 18:30:00 GMT".
+    private static final DateTimeFormatter RSS_DATE =
+            DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss zzz").withLocale(Locale.ENGLISH);
 
     MySyncAdapter(Context context, boolean autoInitialize) {
         super(context, autoInitialize);
@@ -76,13 +82,17 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
         getContext().getContentResolver().delete(CONTENT_URI, null, null);
 
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
-        startRequestForSource(getContext(), prefs.getString(getContext().getString(R.string.news_source), "cnn"));
+        startRequestForSource(getContext(), prefs.getString(getContext().getString(R.string.news_source), "cnn.com"));
     }
 
     public static void startRequestForSource(Context context, String source) {
-        final StringRequest stringRequest = new StringRequest(Request.Method.GET,
-                context.getString(R.string.apiurl, source,
-                        context.getString(R.string.newsapikey)),
+        final String url;
+        if (context.getString(R.string.rss_top_source).equals(source)) {
+            url = context.getString(R.string.rss_top_url);
+        } else {
+            url = context.getString(R.string.apiurl, source);
+        }
+        final StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
                 new MyResponseListener(context, source), new MyErrorListener());
         stringRequest.setTag(context);
         queue.add(stringRequest);
@@ -135,37 +145,68 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
         @Override
         public void onResponse(String response) {
             try {
-                final JSONObject respJSON = new JSONObject(response);
-                final JSONArray array = respJSON.getJSONArray(context.getString(R.string.articles));
+                final XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+                factory.setNamespaceAware(false);
+                final XmlPullParser parser = factory.newPullParser();
+                parser.setInput(new StringReader(response));
+
                 final ArrayList<String> titles = new ArrayList<>();
-                Log.d("nano", "responded with " + array.length() + " articles");
                 context.getContentResolver().delete(CONTENT_URI, null, null);
 
-                for (int i = 0; i < array.length(); i++) {
-                    final JSONObject jsonArticle = array.getJSONObject(i);
-                    if (jsonArticle.get(context.getString(R.string.json_title)).equals(JSONObject.NULL)
-                            || jsonArticle.get(context.getString(R.string.json_title)).equals(JSONObject.NULL)
-                            || jsonArticle.get(context.getString(R.string.cv_url_link)).equals(JSONObject.NULL)
-                            || jsonArticle.get(context.getString(R.string.cv_pub_at)).equals(JSONObject.NULL)
-                            ) {
-                        continue;
+                boolean inItem = false;
+                String title = null, link = null, pubDate = null;
+                int event = parser.getEventType();
+                while (event != XmlPullParser.END_DOCUMENT) {
+                    if (event == XmlPullParser.START_TAG) {
+                        final String name = parser.getName();
+                        if ("item".equals(name)) {
+                            inItem = true;
+                            title = link = pubDate = null;
+                        } else if (inItem && "title".equals(name)) {
+                            title = parser.nextText();
+                        } else if (inItem && "link".equals(name)) {
+                            link = parser.nextText();
+                        } else if (inItem && "pubDate".equals(name)) {
+                            pubDate = parser.nextText();
+                        }
+                    } else if (event == XmlPullParser.END_TAG && "item".equals(parser.getName())) {
+                        inItem = false;
+                        title = stripPublisherSuffix(title);
+                        if (title == null || link == null || title.length() < 1 || titles.contains(title)) {
+                            event = parser.next();
+                            continue;
+                        }
+                        titles.add(title);
+                        final ContentValues contentValues = new ContentValues();
+                        // Google News RSS items carry no image; leave IMG null so the UI shows its placeholder.
+                        contentValues.put(HEADLINE, title);
+                        contentValues.put(SOURCE, source);
+                        contentValues.put(LINK, link);
+                        contentValues.put(DATE, parsePubDateSeconds(pubDate));
+                        context.getContentResolver().insert(CONTENT_URI, contentValues);
                     }
-                    final String title = jsonArticle.getString(context.getString(R.string.json_title));
-                    if (titles.contains(title) || title.length() < 1) {
-                        continue;
-                    }
-                    titles.add(title);
-                    final ContentValues contentValues = new ContentValues();
-                    contentValues.put(IMG, jsonArticle.getString(context.getString(R.string.cv_url_image)));
-                    contentValues.put(HEADLINE, title);
-                    contentValues.put(SOURCE, source);
-                    contentValues.put(LINK, jsonArticle.getString(context.getString(R.string.cv_url_link)));
-                    final DateTime dateTime = new DateTime(jsonArticle.get(context.getString(R.string.cv_pub_at)));
-                    contentValues.put(DATE, dateTime.getMillis() / 1000);
-                    context.getContentResolver().insert(CONTENT_URI, contentValues);
+                    event = parser.next();
                 }
-            } catch (JSONException e) {
+                Log.d("nano", "parsed " + titles.size() + " articles from Google News RSS");
+            } catch (Exception e) {
                 Log.e("nano", "failed to parse news response", e);
+            }
+        }
+
+        // Google News titles end with " - Publisher"; drop it since the source is shown separately.
+        private static String stripPublisherSuffix(String title) {
+            if (title == null) {
+                return null;
+            }
+            final int idx = title.lastIndexOf(" - ");
+            return idx > 0 ? title.substring(0, idx) : title;
+        }
+
+        private static long parsePubDateSeconds(String pubDate) {
+            try {
+                return RSS_DATE.parseDateTime(pubDate).getMillis() / 1000;
+            } catch (Exception e) {
+                return new DateTime().getMillis() / 1000;
             }
         }
     }

--- a/mysyncadapter/src/main/java/com/tbse/threenews/mysyncadapter/MySyncAdapter.java
+++ b/mysyncadapter/src/main/java/com/tbse/threenews/mysyncadapter/MySyncAdapter.java
@@ -18,6 +18,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.preference.PreferenceManager;
+import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -43,6 +44,7 @@ import static android.content.Context.ACCOUNT_SERVICE;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.CONTENT_URI;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.DATE;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.HEADLINE;
+import static com.tbse.threenews.mysyncadapter.MyContentProvider.IMG;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.LINK;
 import static com.tbse.threenews.mysyncadapter.MyContentProvider.SOURCE;
 import static com.tbse.threenews.mysyncadapter.NewsAlarmManager.ACCOUNT;
@@ -54,9 +56,11 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
     private static RequestQueue queue;
     public static HashMap<String, String> sourceToName;
 
-    // Google News RSS publishes RFC-822 dates, e.g. "Tue, 24 Jun 2025 18:30:00 GMT".
-    private static final DateTimeFormatter RSS_DATE =
+    // RSS pubDate is RFC-822; feeds use either a zone name ("GMT") or a numeric offset ("+0000").
+    private static final DateTimeFormatter RSS_DATE_ZONE =
             DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss zzz").withLocale(Locale.ENGLISH);
+    private static final DateTimeFormatter RSS_DATE_OFFSET =
+            DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss Z").withLocale(Locale.ENGLISH);
 
     MySyncAdapter(Context context, boolean autoInitialize) {
         super(context, autoInitialize);
@@ -82,20 +86,33 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
         getContext().getContentResolver().delete(CONTENT_URI, null, null);
 
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
-        startRequestForSource(getContext(), prefs.getString(getContext().getString(R.string.news_source), "cnn.com"));
+        startRequestForSource(getContext(),
+                prefs.getString(getContext().getString(R.string.news_source),
+                        getContext().getString(R.string.default_source)));
     }
 
     public static void startRequestForSource(Context context, String source) {
-        final String url;
-        if (context.getString(R.string.rss_top_source).equals(source)) {
-            url = context.getString(R.string.rss_top_url);
-        } else {
-            url = context.getString(R.string.apiurl, source);
+        final String url = feedUrlForSource(context, source);
+        if (url == null) {
+            Log.e("nano", "no feed URL for source " + source);
+            return;
         }
         final StringRequest stringRequest = new StringRequest(Request.Method.GET, url,
                 new MyResponseListener(context, source), new MyErrorListener());
         stringRequest.setTag(context);
         queue.add(stringRequest);
+    }
+
+    // Map the selected source slug to its RSS feed URL via the index-aligned resource arrays.
+    private static String feedUrlForSource(Context context, String source) {
+        final String[] sources = context.getResources().getStringArray(R.array.newssources);
+        final String[] feeds = context.getResources().getStringArray(R.array.newsfeeds);
+        for (int i = 0; i < sources.length && i < feeds.length; i++) {
+            if (sources[i].equals(source)) {
+                return feeds[i];
+            }
+        }
+        return feeds.length > 0 ? feeds[0] : null;
     }
 
     public static boolean shouldGetNews(Context context) {
@@ -154,20 +171,33 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
                 context.getContentResolver().delete(CONTENT_URI, null, null);
 
                 boolean inItem = false;
-                String title = null, link = null, pubDate = null;
+                String title = null, link = null, pubDate = null, image = null;
+                int imageWidth = -1;
                 int event = parser.getEventType();
                 while (event != XmlPullParser.END_DOCUMENT) {
                     if (event == XmlPullParser.START_TAG) {
                         final String name = parser.getName();
                         if ("item".equals(name)) {
                             inItem = true;
-                            title = link = pubDate = null;
+                            title = link = pubDate = image = null;
+                            imageWidth = -1;
                         } else if (inItem && "title".equals(name)) {
                             title = parser.nextText();
                         } else if (inItem && "link".equals(name)) {
                             link = parser.nextText();
                         } else if (inItem && "pubDate".equals(name)) {
                             pubDate = parser.nextText();
+                        } else if (inItem && ("media:content".equals(name)
+                                || "media:thumbnail".equals(name) || "enclosure".equals(name))) {
+                            final String url = parser.getAttributeValue(null, "url");
+                            if (isImageCandidate(url, parser.getAttributeValue(null, "type"))) {
+                                final int w = parseIntOrZero(parser.getAttributeValue(null, "width"));
+                                // Keep the largest image so upscaling in MyTransform looks decent.
+                                if (image == null || w > imageWidth) {
+                                    image = url;
+                                    imageWidth = w;
+                                }
+                            }
                         }
                     } else if (event == XmlPullParser.END_TAG && "item".equals(parser.getName())) {
                         inItem = false;
@@ -178,7 +208,7 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
                         }
                         titles.add(title);
                         final ContentValues contentValues = new ContentValues();
-                        // Google News RSS items carry no image; leave IMG null so the UI shows its placeholder.
+                        contentValues.put(IMG, image);
                         contentValues.put(HEADLINE, title);
                         contentValues.put(SOURCE, source);
                         contentValues.put(LINK, link);
@@ -187,13 +217,33 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
                     }
                     event = parser.next();
                 }
-                Log.d("nano", "parsed " + titles.size() + " articles from Google News RSS");
+                Log.d("nano", "parsed " + titles.size() + " articles from " + source);
             } catch (Exception e) {
                 Log.e("nano", "failed to parse news response", e);
             }
         }
 
-        // Google News titles end with " - Publisher"; drop it since the source is shown separately.
+        private static boolean isImageCandidate(String url, String type) {
+            if (TextUtils.isEmpty(url)) {
+                return false;
+            }
+            if (type != null && type.startsWith("image")) {
+                return true;
+            }
+            final String lower = url.toLowerCase(Locale.US);
+            return lower.contains(".jpg") || lower.contains(".jpeg")
+                    || lower.contains(".png") || lower.contains(".webp");
+        }
+
+        private static int parseIntOrZero(String s) {
+            try {
+                return s == null ? 0 : Integer.parseInt(s.trim());
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+
+        // Some aggregated feeds end titles with " - Publisher"; drop it (the source is shown separately).
         private static String stripPublisherSuffix(String title) {
             if (title == null) {
                 return null;
@@ -203,11 +253,18 @@ public class MySyncAdapter extends AbstractThreadedSyncAdapter {
         }
 
         private static long parsePubDateSeconds(String pubDate) {
-            try {
-                return RSS_DATE.parseDateTime(pubDate).getMillis() / 1000;
-            } catch (Exception e) {
-                return new DateTime().getMillis() / 1000;
+            if (pubDate != null) {
+                try {
+                    return RSS_DATE_ZONE.parseDateTime(pubDate.trim()).getMillis() / 1000;
+                } catch (Exception ignored) {
+                    try {
+                        return RSS_DATE_OFFSET.parseDateTime(pubDate.trim()).getMillis() / 1000;
+                    } catch (Exception ignored2) {
+                        // fall through
+                    }
+                }
             }
+            return new DateTime().getMillis() / 1000;
         }
     }
 

--- a/mysyncadapter/src/main/res/values/apikeys.xml
+++ b/mysyncadapter/src/main/res/values/apikeys.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="newsapikey" translatable="false">xxxxxyyyyyy1111112222233333</string>
-</resources>

--- a/mysyncadapter/src/main/res/values/newsfeeds.xml
+++ b/mysyncadapter/src/main/res/values/newsfeeds.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- RSS feed URLs, index-aligned with newssources / newssourcesnames. -->
+    <string-array name="newsfeeds" translatable="false">
+        <item>https://feeds.bbci.co.uk/news/rss.xml</item>
+        <item>https://abcnews.go.com/abcnews/topstories</item>
+        <item>https://feeds.nbcnews.com/nbcnews/public/news</item>
+        <item>https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml</item>
+        <item>https://www.theguardian.com/world/rss</item>
+        <item>https://feeds.arstechnica.com/arstechnica/index</item>
+        <item>https://www.wired.com/feed/rss</item>
+        <item>https://feeds.skynews.com/feeds/rss/world.xml</item>
+    </string-array>
+</resources>

--- a/mysyncadapter/src/main/res/values/newssources.xml
+++ b/mysyncadapter/src/main/res/values/newssources.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!--
-        Values are the site domain passed to Google News RSS as `site:<domain>`.
-        The special value "top" selects Google News' unified top-stories feed.
-        Keep this array index-aligned with newssourcesnames.
+        Source slugs. Each is index-aligned with newssourcesnames (display name)
+        and newsfeeds (RSS feed URL). All feeds are HTTPS and carry images.
     -->
     <string-array name="newssources">
-        <item>apnews.com</item>
-        <item>cnn.com</item>
-        <item>top</item>
-        <item>news.ycombinator.com</item>
-        <item>nytimes.com</item>
-        <item>reuters.com</item>
-        <item>techcrunch.com</item>
-        <item>time.com</item>
-        <item>washingtonpost.com</item>
+        <item>bbc</item>
+        <item>abc</item>
+        <item>nbc</item>
+        <item>nyt</item>
+        <item>guardian</item>
+        <item>arstechnica</item>
+        <item>wired</item>
+        <item>skynews</item>
     </string-array>
 </resources>

--- a/mysyncadapter/src/main/res/values/newssources.xml
+++ b/mysyncadapter/src/main/res/values/newssources.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!--
+        Values are the site domain passed to Google News RSS as `site:<domain>`.
+        The special value "top" selects Google News' unified top-stories feed.
+        Keep this array index-aligned with newssourcesnames.
+    -->
     <string-array name="newssources">
-        <item>associated-press</item>
-        <item>cnn</item>
-        <item>google-news</item>
-        <item>hacker-news</item>
-        <item>the-new-york-times</item>
-        <item>reuters</item>
-        <item>techcrunch</item>
-        <item>time</item>
-        <item>the-washington-post</item>
+        <item>apnews.com</item>
+        <item>cnn.com</item>
+        <item>top</item>
+        <item>news.ycombinator.com</item>
+        <item>nytimes.com</item>
+        <item>reuters.com</item>
+        <item>techcrunch.com</item>
+        <item>time.com</item>
+        <item>washingtonpost.com</item>
     </string-array>
 </resources>

--- a/mysyncadapter/src/main/res/values/newssourcesnames.xml
+++ b/mysyncadapter/src/main/res/values/newssourcesnames.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="newssourcesnames">
-        <item>AP</item>
-        <item>CNN</item>
-        <item>Google News</item>
-        <item>Hacker News</item>
+        <item>BBC News</item>
+        <item>ABC News</item>
+        <item>NBC News</item>
         <item>New York Times</item>
-        <item>Reuters</item>
-        <item>TechCrunch</item>
-        <item>Time</item>
-        <item>Washington Post</item>
+        <item>The Guardian</item>
+        <item>Ars Technica</item>
+        <item>WIRED</item>
+        <item>Sky News</item>
     </string-array>
 </resources>

--- a/mysyncadapter/src/main/res/values/strings.xml
+++ b/mysyncadapter/src/main/res/values/strings.xml
@@ -1,12 +1,8 @@
 <resources>
     <string name="app_name">My Sync Adapter</string>
-    <!-- Google News RSS. %1$s is a site domain (e.g. cnn.com); when:2d limits to the last 2 days. -->
-    <string name="apiurl" translatable="false">https://news.google.com/rss/search?q=site:%1$s+when:2d&amp;hl=en-US&amp;gl=US&amp;ceid=US:en</string>
-    <!-- Unified top-stories feed, used when the selected source is "top". -->
-    <string name="rss_top_url" translatable="false">https://news.google.com/rss?hl=en-US&amp;gl=US&amp;ceid=US:en</string>
-    <string name="rss_top_source" translatable="false">top</string>
     <string name="cantupdateondata">Can\'t update news while on mobile data!</string>
     <string name="news_source">news_source</string>
+    <string name="default_source" translatable="false">bbc</string>
     <string name="pref_allow_mobile_data">allow-mobile-data</string>
     <string name="alarm_action_name">com.tbse.threenews.alarm</string>
 </resources>

--- a/mysyncadapter/src/main/res/values/strings.xml
+++ b/mysyncadapter/src/main/res/values/strings.xml
@@ -1,13 +1,12 @@
 <resources>
     <string name="app_name">My Sync Adapter</string>
-    <string name="apiurl" translatable="false">https://newsapi.org/v1/articles?source=%1$s&amp;apiKey=%2$s</string>
+    <!-- Google News RSS. %1$s is a site domain (e.g. cnn.com); when:2d limits to the last 2 days. -->
+    <string name="apiurl" translatable="false">https://news.google.com/rss/search?q=site:%1$s+when:2d&amp;hl=en-US&amp;gl=US&amp;ceid=US:en</string>
+    <!-- Unified top-stories feed, used when the selected source is "top". -->
+    <string name="rss_top_url" translatable="false">https://news.google.com/rss?hl=en-US&amp;gl=US&amp;ceid=US:en</string>
+    <string name="rss_top_source" translatable="false">top</string>
     <string name="cantupdateondata">Can\'t update news while on mobile data!</string>
     <string name="news_source">news_source</string>
     <string name="pref_allow_mobile_data">allow-mobile-data</string>
-    <string name="json_title">title</string>
-    <string name="cv_url_image">urlToImage</string>
-    <string name="cv_url_link">url</string>
-    <string name="cv_pub_at">publishedAt</string>
-    <string name="articles">articles</string>
     <string name="alarm_action_name">com.tbse.threenews.alarm</string>
 </resources>


### PR DESCRIPTION
## Why
The app couldn't fetch news: the key in `apikeys.xml` was a placeholder and the URL targeted **newsapi.org v1**, an endpoint shut down years ago. newsapi.org's free tier also needs a key and only works on localhost/dev.

## What
Replaces newsapi.org with the **news outlets' own public RSS feeds** — free, no API key, no quota, and **each story carries its image**. (An earlier iteration of this branch used Google News RSS, but those items have no images, so every tile fell back to the placeholder; direct outlet feeds fixed that.) Everything downstream of the fetch — ContentProvider → CursorLoader → 3-pane UI + widget — is unchanged.

- **Sources** (all HTTPS, all verified to embed images): BBC, ABC, NBC, New York Times, The Guardian, Ars Technica, WIRED, Sky News. CNN was dropped because its feed is HTTP-only, which API 34 blocks by default.
- **Resource model**: three index-aligned arrays — `newssources.xml` (slug), `newssourcesnames.xml` (display name), `newsfeeds.xml` (feed URL). `default_source` = `bbc`.
- **`MySyncAdapter`**: resolves slug → feed URL, fetches via Volley, parses RSS XML with Android's built-in `XmlPullParser` (no new dependency). Each item's image is taken from `media:content` / `media:thumbnail` / `enclosure` (largest by `width`). `pubDate` is parsed as RFC-822 with either a zone name (`GMT`) or numeric offset (`+0000`). The trailing " - Publisher" suffix is stripped from titles.
- **Removed** `apikeys.xml` (no key needed); updated `README.md` and `CLAUDE.md`.

## Verification
- `./gradlew :mobile:assembleRelease` and `./gradlew test` → **BUILD SUCCESSFUL**.
- Installed on a physical **Pixel 9 Pro XL**: logcat shows `parsed 39 articles from bbc`, and all three panes render real photos with headlines. ABC/NBC and the rest confirmed to expose `.jpg` image tags the parser accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)