### PR TITLE
Fix refresh leaving lower story panes stale

### DIFF
--- a/mobile/src/main/java/com/tbse/threenews/MainNewsActivity.java
+++ b/mobile/src/main/java/com/tbse/threenews/MainNewsActivity.java
@@ -321,10 +321,6 @@ public class MainNewsActivity extends AppCompatActivity
                     final TextView headlineTV = (TextView) view.findViewById(R.id.headline);
                     final ImageView storyImage = (ImageView) view.findViewById(R.id.story_image);
 
-                    if (headline.equals(headlineTV.getText().toString())) {
-                        return;
-                    }
-
                     storyImage.setContentDescription(headline);
 
                     final MyTransform myTransform;


### PR DESCRIPTION
## Problem
On each ~60s refresh, lower story panes could keep showing an old article even when the feed brought in a newer one.

## Cause
`MyContentObserver.onChange` iterates the three panes in order and bailed out of the **whole** loop with `return` as soon as one pane's headline equaled what was already displayed. So an unchanged pane stopped every pane after it from updating. The check was also inconsistent — pane 0's text carries a `"<source>: "` prefix, so it never matched in the first place.

## Fix
Remove the early-out so all three panes always reflect the current newest 3 articles. Picasso caches by URL, so unchanged images don't reload or flicker.

## Verification
- `./gradlew :mobile:assembleRelease` → **BUILD SUCCESSFUL**.
- Installed on a physical **Pixel 9 Pro XL**; auto-refresh confirmed firing ~every 60s (logcat), three panes render correctly with no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)